### PR TITLE
Update maven-war-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.3.1</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>


### PR DESCRIPTION
Version 2.3 results in a failed build on Ubuntu 22.04.1 LTS. The build completes successfully using version 3.3.1.